### PR TITLE
Define syntax and restore some uints

### DIFF
--- a/src/POGOProtos/Networking/Envelopes/SignalAgglomUpdates.proto
+++ b/src/POGOProtos/Networking/Envelopes/SignalAgglomUpdates.proto
@@ -1,10 +1,12 @@
+syntax = "proto3";
+
 // Note: Some int32's in these messages may actually be float values, but due to how things are serialized, and little backing-data
 // I can't confirm them being floats or not. All others are confirmed.
 // Note2: In the native lib, it does not look like they actually serialize to float. They use float datatypes in native structures, but serialize to doubles
 // Note3: We really shouldn't call this 'Signature' it's an agglomerated update packet for device reading changes + request hashes
 message SignalAgglomUpdates {
 	repeated UnknownMessage field1 = 1;
-	int64 timestamp_ms_since_start = 2;
+	uint64 timestamp_ms_since_start = 2;
 	string field3 = 3;
 	repeated LocationUpdate location_updates = 4;  // Multiple location updates at a time. This is all the updates since the last time we sent a request
 	repeated AndroidGpsInfo android_gps_info = 5;
@@ -12,7 +14,7 @@ message SignalAgglomUpdates {
 	repeated SensorUpdate sensor_updates = 7;  // All the sensor updates since the last time we sent a request. (Seems to actually be throttled to 1-3 at a time)
 	DeviceInfo device_info = 8;                // device info - need to find this still to verify everything
 	IOSDeviceInfo ios_device_info = 9;         // iOS only - likely device capabilities? (Or even simpler being iOS device version flags)
-	int32 location_hash_by_token_seed = 10;    // Hashed location using the auth token as the seed (hashed auth token -> location hash seed)
+	uint32 location_hash_by_token_seed = 10;   // Hashed location using the auth token as the seed (hashed auth token -> location hash seed)
 	bool field11 = 11;
 	bool field12 = 12;
 	int32 field13 = 13;
@@ -22,11 +24,11 @@ message SignalAgglomUpdates {
 	string field17 = 17;
 	string field18 = 18;
 	bool field19 = 19;
-	int32 location_hash = 20;
+	uint32 location_hash = 20;
 	bool field21 = 21;
 	bytes field22 = 22;  // replay check - Changes every 5 minutes or so. Generation unknown but pointed to by 0001B8614
 	uint64 epoch_timestamp_ms = 23;
-	repeated int64 request_hashes = 24;  // xxHash64 of the requests being sent with this agglom
+	repeated uint64 request_hashes = 24;  // xxHash64 of the requests being sent with this agglom
 	uint64 field25 = 25;
 
 	// 100% - Reference iOS lib "LocationUpdate" structure for bridge


### PR DESCRIPTION
Restore the `uint` type to some fields that would otherwise fail to store valid values, and define the syntax type at the top to avoid compilation failures.