### PR TITLE
Change hashes back to ints

### DIFF
--- a/src/POGOProtos/Networking/Envelopes/SignalAgglomUpdates.proto
+++ b/src/POGOProtos/Networking/Envelopes/SignalAgglomUpdates.proto
@@ -6,7 +6,7 @@ syntax = "proto3";
 // Note3: We really shouldn't call this 'Signature' it's an agglomerated update packet for device reading changes + request hashes
 message SignalAgglomUpdates {
 	repeated UnknownMessage field1 = 1;
-	uint64 timestamp_ms_since_start = 2;
+	int64 timestamp_ms_since_start = 2;
 	string field3 = 3;
 	repeated LocationUpdate location_updates = 4;  // Multiple location updates at a time. This is all the updates since the last time we sent a request
 	repeated AndroidGpsInfo android_gps_info = 5;
@@ -14,7 +14,7 @@ message SignalAgglomUpdates {
 	repeated SensorUpdate sensor_updates = 7;  // All the sensor updates since the last time we sent a request. (Seems to actually be throttled to 1-3 at a time)
 	DeviceInfo device_info = 8;                // device info - need to find this still to verify everything
 	IOSDeviceInfo ios_device_info = 9;         // iOS only - likely device capabilities? (Or even simpler being iOS device version flags)
-	uint32 location_hash_by_token_seed = 10;   // Hashed location using the auth token as the seed (hashed auth token -> location hash seed)
+	int32 location_hash_by_token_seed = 10;    // Hashed location using the auth token as the seed (hashed auth token -> location hash seed)
 	bool field11 = 11;
 	bool field12 = 12;
 	int32 field13 = 13;
@@ -24,11 +24,11 @@ message SignalAgglomUpdates {
 	string field17 = 17;
 	string field18 = 18;
 	bool field19 = 19;
-	uint32 location_hash = 20;
+	int32 location_hash = 20;
 	bool field21 = 21;
 	bytes field22 = 22;  // replay check - Changes every 5 minutes or so. Generation unknown but pointed to by 0001B8614
 	uint64 epoch_timestamp_ms = 23;
-	repeated uint64 request_hashes = 24;  // xxHash64 of the requests being sent with this agglom
+	repeated int64 request_hashes = 24;  // xxHash64 of the requests being sent with this agglom
 	uint64 field25 = 25;
 
 	// 100% - Reference iOS lib "LocationUpdate" structure for bridge


### PR DESCRIPTION
These actually are `int`s, the problem was with the values that pgoapi was passing, but that has been fixed in pogodevorg/pgoapi@f536defe67c1198a15c920c5246ceaef6fc2c68c.

Other APIs may have issues with these data types being correct, but that should be fixed in their code.